### PR TITLE
allow .skip and .only on top level modules.

### DIFF
--- a/lib/ember-mocha/describe-component.js
+++ b/lib/ember-mocha/describe-component.js
@@ -1,6 +1,10 @@
-import { createModule } from './mocha-module';
+import { createModule, createOnly, createSkip } from './mocha-module';
 import { TestModuleForComponent } from 'ember-test-helpers';
 
 export default function describeComponent(name, description, callbacks, tests) {
   createModule(TestModuleForComponent, name, description, callbacks, tests);
 }
+
+describeComponent.only = createOnly(TestModuleForComponent);
+
+describeComponent.skip = createSkip(TestModuleForComponent);

--- a/lib/ember-mocha/describe-model.js
+++ b/lib/ember-mocha/describe-model.js
@@ -1,6 +1,10 @@
-import { createModule } from './mocha-module';
+import { createModule, createOnly, createSkip } from './mocha-module';
 import { TestModuleForModel } from 'ember-test-helpers';
 
 export default function describeModel(name, description, callbacks, tests) {
   createModule(TestModuleForModel, name, description, callbacks, tests);
 }
+
+describeModel.only = createOnly(TestModuleForModel);
+
+describeModel.skip = createSkip(TestModuleForModel);

--- a/lib/ember-mocha/describe-module.js
+++ b/lib/ember-mocha/describe-module.js
@@ -1,6 +1,10 @@
-import { createModule } from './mocha-module';
+import { createModule, createOnly, createSkip } from './mocha-module';
 import { TestModule } from 'ember-test-helpers';
 
 export default function describeModule(name, description, callbacks, tests) {
   createModule(TestModule, name, description, callbacks, tests);
 }
+
+describeModule.only = createOnly(TestModule);
+
+describeModule.skip = createSkip(TestModule);

--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { getContext } from 'ember-test-helpers';
 
-export function createModule(Constructor, name, description, callbacks, tests) {
+export function createModule(Constructor, name, description, callbacks, tests, method) {
   var module;
 
   if (!tests) {
@@ -18,7 +18,8 @@ export function createModule(Constructor, name, description, callbacks, tests) {
     module = new Constructor(name, description, callbacks);
   }
 
-  describe(module.name, function() {
+
+  function moduleBody() {
     beforeEach(function() {
       module.setup();
       var context = getContext();
@@ -33,6 +34,24 @@ export function createModule(Constructor, name, description, callbacks, tests) {
       module.teardown();
     });
 
+    tests = tests || function() {};
     tests();
-  });
+  }
+  if (method) {
+    describe[method](module.name, moduleBody);
+  } else {
+    describe(module.name, moduleBody);
+  }
+}
+
+export function createOnly(Constructor) {
+  return function(name, description, callbacks, tests) {
+    createModule(Constructor, name, description, callbacks, tests, "only");
+  };
+}
+
+export function createSkip(Constructor) {
+  return function(name, description, callbacks, tests) {
+    createModule(Constructor, name, description, callbacks, tests, "skip");
+  };
 }

--- a/tests/describe-component-test.js
+++ b/tests/describe-component-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { describeComponent, it } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
+import { grepFor } from './test-support/mocha-support';
 
 window.expect = chai.expect;
 
@@ -22,84 +23,110 @@ function setupRegistry() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-describeComponent('x-foo', {
+describe('describeComponent', function() {
 
-  beforeSetup: function() {
-    setupRegistry();
-  }
 
-}, function() {
 
-  it('renders', function() {
-    var component = this.subject();
-    expect(component._state).to.equal('preRender');
-    this.render();
-    expect(component._state).to.equal('inDOM');
-  });
+  describeComponent('x-foo', {
 
-  it('appends', function() {
-    var component = this.subject();
-    expect(component._state).to.equal('preRender');
-    this.append();
-    expect(component._state).to.equal('inDOM');
-  });
+    beforeSetup: function() {
+      setupRegistry();
+    }
 
-  it('yields', function() {
-    var component = this.subject({
-      layout: Ember.Handlebars.compile("yield me")
-    });
-    expect(component._state).to.equal('preRender');
-    this.render();
-    expect(component._state).to.equal('inDOM');
-  });
+  }, function() {
 
-  it('can lookup components in its layout', function() {
-    var component = this.subject({
-      layout: Ember.Handlebars.compile("{{x-foo id='yodawg-i-heard-you-liked-x-foo-in-ur-x-foo'}}")
-    });
-    this.render();
-    expect(component._state).to.equal('inDOM');
-  });
-
-  it('clears out views from test to test', function() {
-    this.subject({
-      layout: Ember.Handlebars.compile("{{x-foo id='yodawg-i-heard-you-liked-x-foo-in-ur-x-foo'}}")
-    });
-    this.render();
-    expect(true).to.equal(true); // rendered without id already being used from another test
-  });
-});
-
-///////////////////////////////////////////////////////////////////////////////
-
-describeComponent('pretty-color', {
-
-  beforeSetup: function() {
-    setupRegistry();
-  }
-
-}, function() {
-
-  it("has the correct className", function() {
-    // first call to this.$() renders the component.
-    expect(this.$().is('.pretty-color')).to.be.true;
-  });
-
-  it("uses the correct custom template", function() {
-    var component = this.subject();
-
-    expect($.trim(this.$().text())).to.equal('Pretty Color:');
-
-    Ember.run(function() {
-      component.set('name', 'green');
+    it('renders', function() {
+      var component = this.subject();
+      expect(component._state).to.equal('preRender');
+      this.render();
+      expect(component._state).to.equal('inDOM');
     });
 
-    expect($.trim(this.$().text())).to.equal('Pretty Color: green');
+    it('appends', function() {
+      var component = this.subject();
+      expect(component._state).to.equal('preRender');
+      this.append();
+      expect(component._state).to.equal('inDOM');
+    });
+
+    it('yields', function() {
+      var component = this.subject({
+        layout: Ember.Handlebars.compile("yield me")
+      });
+      expect(component._state).to.equal('preRender');
+      this.render();
+      expect(component._state).to.equal('inDOM');
+    });
+
+    it('can lookup components in its layout', function() {
+      var component = this.subject({
+        layout: Ember.Handlebars.compile("{{x-foo id='yodawg-i-heard-you-liked-x-foo-in-ur-x-foo'}}")
+      });
+      this.render();
+      expect(component._state).to.equal('inDOM');
+    });
+
+    it('clears out views from test to test', function() {
+      this.subject({
+        layout: Ember.Handlebars.compile("{{x-foo id='yodawg-i-heard-you-liked-x-foo-in-ur-x-foo'}}")
+      });
+      this.render();
+      expect(true).to.equal(true); // rendered without id already being used from another test
+    });
   });
 
-  it("$", function() {
-    var component = this.subject({name: 'green'});
-    expect($.trim(this.$('.color-name').text())).to.equal('green');
-    expect($.trim(this.$().text())).to.equal('Pretty Color: green');
+
+  ///////////////////////////////////////////////////////////////////////////////
+
+  describeComponent('pretty-color', {
+
+    beforeSetup: function() {
+      setupRegistry();
+    }
+
+  }, function() {
+
+    it("has the correct className", function() {
+      // first call to this.$() renders the component.
+      expect(this.$().is('.pretty-color')).to.be.true;
+    });
+
+    it("uses the correct custom template", function() {
+      var component = this.subject();
+
+      expect($.trim(this.$().text())).to.equal('Pretty Color:');
+
+      Ember.run(function() {
+        component.set('name', 'green');
+      });
+
+      expect($.trim(this.$().text())).to.equal('Pretty Color: green');
+    });
+
+    it("$", function() {
+      var component = this.subject({name: 'green'});
+      expect($.trim(this.$('.color-name').text())).to.equal('green');
+      expect($.trim(this.$().text())).to.equal('Pretty Color: green');
+    });
+  });
+
+  describeComponent.skip('skipped component', function() {
+    it("is skipped", function() {});
+  });
+  var grep = grepFor(function() {
+    describeComponent.only('only component', function() {
+      it("is the only spec");
+    });
+  });
+
+  describe("skipping and grepping", function() {
+    it("skips the skipped context", function() {
+      var skipped = window.mocha.suite.suites.find(function(suite) {
+        return suite.title === "skipped component" && suite.pending;
+      });
+    });
+    it("greps for describeComponent.only", function() {
+      expect('describeComponent component:only component').to.match(grep);
+    });
   });
 });

--- a/tests/describe-model-test.js
+++ b/tests/describe-model-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { describeModel, it } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
+import { grepFor } from './test-support/mocha-support';
 
 window.expect = chai.expect;
 
@@ -25,104 +26,128 @@ function setupRegistry() {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-describeModel('whazzit', 'model:whazzit without adapter', {
+describe('describeModel', function() {
 
-  beforeSetup: function() {
-    setupRegistry();
-  },
+  describeModel('whazzit', 'model:whazzit without adapter', {
 
-  setup: function() {
-    Whazzit.FIXTURES = [];
-  }
+    beforeSetup: function() {
+      setupRegistry();
+    },
 
-}, function() {
+    setup: function() {
+      Whazzit.FIXTURES = [];
+    }
 
-  it('store exists', function() {
-    var store = this.store();
-    expect(store).to.be.an.instanceof(DS.Store);
-  });
+  }, function() {
 
-  it('model exists as subject', function() {
-    var model = this.subject();
-    expect(model).to.exist;
-    expect(model).to.be.an.instanceof(DS.Model);
-    expect(model).to.be.an.instanceof(Whazzit);
-  });
+    it('store exists', function() {
+      var store = this.store();
+      expect(store).to.be.an.instanceof(DS.Store);
+    });
 
-  it('model is using the FixtureAdapter', function() {
-    var model = this.subject(),
-        store = this.store();
+    it('model exists as subject', function() {
+      var model = this.subject();
+      expect(model).to.exist;
+      expect(model).to.be.an.instanceof(DS.Model);
+      expect(model).to.be.an.instanceof(Whazzit);
+    });
 
-    expect(store.adapterFor(model.constructor)).to.be.an.instanceof(DS.FixtureAdapter);
-    expect(store.adapterFor(model.constructor)).to.not.be.an.instanceof(WhazzitAdapter);
-  });
-});
+    it('model is using the FixtureAdapter', function() {
+      var model = this.subject(),
+          store = this.store();
 
-///////////////////////////////////////////////////////////////////////////////
-
-describeModel('whazzit', 'model:whazzit with custom adapter', {
-
-  needs: ['adapter:whazzit'],
-
-  beforeSetup: function() {
-    setupRegistry();
-  },
-
-  setup: function() {
-    Whazzit.FIXTURES = [];
-    whazzitAdapterFindAllCalled = false;
-  }
-
-}, function() {
-
-  it('uses the WhazzitAdapter', function() {
-    var model = this.subject(),
-        store = this.store();
-
-    expect(store.adapterFor(model.constructor)).to.be.an.instanceof(WhazzitAdapter);
-  });
-
-  it('uses the WhazzitAdapter for a `find` request', function(done) {
-    var model = this.subject(),
-        store = this.store();
-
-    expect(whazzitAdapterFindAllCalled).to.be.false;
-
-    store = this.store();
-
-    return Ember.run(function() {
-      return store.find('whazzit').then(function() {
-        expect(whazzitAdapterFindAllCalled).to.be.true;
-        done();
-      });
+      expect(store.adapterFor(model.constructor)).to.be.an.instanceof(DS.FixtureAdapter);
+      expect(store.adapterFor(model.constructor)).to.not.be.an.instanceof(WhazzitAdapter);
     });
   });
 
-});
+  ///////////////////////////////////////////////////////////////////////////////
 
-///////////////////////////////////////////////////////////////////////////////
+  describeModel('whazzit', 'model:whazzit with custom adapter', {
 
-describeModel('whazzit', 'model:whazzit with application adapter', {
+    needs: ['adapter:whazzit'],
 
-  needs: ['adapter:application'],
+    beforeSetup: function() {
+      setupRegistry();
+    },
 
-  beforeSetup: function() {
-    setupRegistry();
-  },
+    setup: function() {
+      Whazzit.FIXTURES = [];
+      whazzitAdapterFindAllCalled = false;
+    }
 
-  setup: function() {
-    Whazzit.FIXTURES = [];
-  }
+  }, function() {
 
-}, function() {
+    it('uses the WhazzitAdapter', function() {
+      var model = this.subject(),
+          store = this.store();
 
-  it('uses the ApplicationAdapter', function() {
-    var model = this.subject(),
+      expect(store.adapterFor(model.constructor)).to.be.an.instanceof(WhazzitAdapter);
+    });
+
+    it('uses the WhazzitAdapter for a `find` request', function(done) {
+      var model = this.subject(),
+          store = this.store();
+
+      expect(whazzitAdapterFindAllCalled).to.be.false;
+
       store = this.store();
 
-    expect(store.adapterFor(model.constructor)).to.be.an.instanceof(ApplicationAdapter);
-    expect(store.adapterFor(model.constructor)).to.not.be.an.instanceof(WhazzitAdapter);
+      return Ember.run(function() {
+        return store.find('whazzit').then(function() {
+          expect(whazzitAdapterFindAllCalled).to.be.true;
+          done();
+        });
+      });
+    });
+
   });
 
-});
+  ///////////////////////////////////////////////////////////////////////////////
 
+  describeModel('whazzit', 'model:whazzit with application adapter', {
+
+    needs: ['adapter:application'],
+
+    beforeSetup: function() {
+      setupRegistry();
+    },
+
+    setup: function() {
+      Whazzit.FIXTURES = [];
+    }
+
+  }, function() {
+
+    it('uses the ApplicationAdapter', function() {
+      var model = this.subject(),
+          store = this.store();
+
+      expect(store.adapterFor(model.constructor)).to.be.an.instanceof(ApplicationAdapter);
+      expect(store.adapterFor(model.constructor)).to.not.be.an.instanceof(WhazzitAdapter);
+    });
+
+  });
+
+
+  describeModel.skip("skipped model", function() {
+    it("is skipped", function() {});
+  });
+
+  var grep = grepFor(function() {
+    describeModel.only("whazzit", "only model", function() {
+      it("is the only model", function() {});
+    });
+  });
+
+  describe("skipping and grepping", function() {
+    it("skips the skipped context", function() {
+      var skipped = window.mocha.suite.suites.find(function(suite) {
+        return suite.title === "skipped model" && suite.pending;
+      });
+    });
+    it("greps for describeModel.only", function() {
+      expect('describeModel only model').to.match(grep);
+    });
+  });
+});

--- a/tests/describe-module-test.js
+++ b/tests/describe-module-test.js
@@ -1,5 +1,6 @@
 import { describeModule, it } from 'ember-mocha';
 import { setResolverRegistry } from 'tests/test-support/resolver';
+import { grepFor } from './test-support/mocha-support';
 
 window.expect = chai.expect;
 
@@ -11,40 +12,64 @@ function setupRegistry() {
 
 var callbackOrder, setupContext, teardownContext, beforeSetupContext, afterTeardownContext;
 
-describeModule('component:x-foo', 'TestModule callbacks', {
-  beforeSetup: function() {
-    beforeSetupContext = this;
-    callbackOrder = [ 'beforeSetup' ];
+describe("describeModule", function() {
 
-    setupRegistry();
-  },
+  describeModule('component:x-foo', 'TestModule callbacks', {
+    beforeSetup: function() {
+      beforeSetupContext = this;
+      callbackOrder = [ 'beforeSetup' ];
 
-  setup: function() {
-    setupContext = this;
-    callbackOrder.push('setup');
+      setupRegistry();
+    },
 
-    expect(setupContext).to.not.equal(beforeSetupContext);
-  },
+    setup: function() {
+      setupContext = this;
+      callbackOrder.push('setup');
 
-  teardown: function() {
-    teardownContext = this;
-    callbackOrder.push('teardown');
+      expect(setupContext).to.not.equal(beforeSetupContext);
+    },
 
-    expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup', 'teardown']);
-    expect(setupContext).to.equal(teardownContext);
-  },
+    teardown: function() {
+      teardownContext = this;
+      callbackOrder.push('teardown');
 
-  afterTeardown: function() {
-    afterTeardownContext = this;
-    callbackOrder.push('afterTeardown');
+      expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup', 'teardown']);
+      expect(setupContext).to.equal(teardownContext);
+    },
 
-    expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup', 'teardown', 'afterTeardown']);
-    expect(afterTeardownContext).to.equal(beforeSetupContext);
-    expect(afterTeardownContext).to.not.equal(teardownContext);
-  }
+    afterTeardown: function() {
+      afterTeardownContext = this;
+      callbackOrder.push('afterTeardown');
 
-}, function() {
-  it("should call setup callbacks in the correct order", function() {
-    expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup' ]);
+      expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup', 'teardown', 'afterTeardown']);
+      expect(afterTeardownContext).to.equal(beforeSetupContext);
+      expect(afterTeardownContext).to.not.equal(teardownContext);
+    }
+
+  }, function() {
+    it("should call setup callbacks in the correct order", function() {
+      expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup' ]);
+    });
+  });
+
+  describeModule.skip("skipped module", function() {
+    it("is skipped", function() {});
+  });
+
+  var grep = grepFor(function() {
+    describeModule.only("component:x-foo", "only module", function() {
+      it("is the only module", function() {});
+    });
+  });
+
+  describe("skipping and grepping", function() {
+    it("skips the skipped context", function() {
+      var skipped = window.mocha.suite.suites.find(function(suite) {
+        return suite.title === "skipped module" && suite.pending;
+      });
+    });
+    it("greps for describeModule.only", function() {
+      expect('describeModule only module').to.match(grep);
+    });
   });
 });

--- a/tests/it-test.js
+++ b/tests/it-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { it } from 'ember-mocha';
+import { grepFor } from './test-support/mocha-support';
 
 window.expect = chai.expect;
 
@@ -55,12 +56,10 @@ describe('it', function() {
   it('correctly sets mocha grep options for runing a single test case with.only', function() {
     expect(mochaGrep).to.match(/it runs this test/);
   });
-  var originalMochaGrep;
-  var mochaGrep;
-  it.only('runs this test', function() {});
-  mochaGrep = Mocha.options.grep;
-  Mocha.options.grep = originalMochaGrep;
 
+  var mochaGrep = grepFor(function() {
+    it.only('runs this test');
+  });
 
   var skippedError = tryMochaSpecifier(function() {
     it.skip('is a skipped spec');

--- a/tests/test-support/mocha-support.js
+++ b/tests/test-support/mocha-support.js
@@ -1,0 +1,20 @@
+/**
+ * Captures mocha grep options for a. That way you can run describe
+ * block or an `it` block that may narrow the mocha test run, but
+ * those options will be reset afterwards. E.g.
+ *
+ *   var grep = grepFor(function() {
+ *     it.skip('this is skipped');
+ *   })
+ *   console.log(grep) //=> /this is skipped/
+*/
+export function grepFor(fn) {
+  var options = window.mocha.options;
+  var originalMochaGrep = options.grep;
+  try {
+    fn();
+    return options.grep;
+  } finally {
+    options.grep = originalMochaGrep;
+  }
+}


### PR DESCRIPTION
This allows you to mark top-level describeModule and friends as
pending. It also allows you to set them as the only scope to run.

This brings the api in line with vanilla mocha `describe`