### PR TITLE
ensure that context is preserved in setup/teardown

### DIFF
--- a/tests/mocha-module-test.js
+++ b/tests/mocha-module-test.js
@@ -1,0 +1,27 @@
+import { createModule } from 'ember-mocha/mocha-module';
+import { TestModule } from 'ember-test-helpers';
+
+describe('MochaModule', function() {
+  createModule(TestModule, 'component:x-foo', 'context', function() {
+    var thisInBefore, thisInBeforeEach;
+
+    before(function() {
+      thisInBefore = this;
+    });
+    beforeEach(function() {
+      thisInBeforeEach = this;
+    });
+    it("is preserved inside all assertions and hooks", function() {
+      expect(this).to.be.defined;
+      expect(this).to.equal(thisInBefore);
+      expect(this).to.equal(thisInBeforeEach);
+    });
+    afterEach(function() {
+      expect(this).to.equal(thisInBeforeEach);
+    });
+    after(function() {
+      expect(this).to.equal(thisInBefore);
+      expect(this).to.equal(thisInBeforeEach);
+    });
+  });
+});


### PR DESCRIPTION
This wraps tests around the functionality introduced with #6 to prevent regressions per the discussion in #14 