### PR TITLE
Use git-repo-version instead of git-repo-info directly.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -4,7 +4,7 @@ var mergeTrees = require('broccoli-merge-trees');
 var compileES6 = require('broccoli-es6modules');
 var jshintTree = require('broccoli-jshint');
 var replace    = require('broccoli-string-replace');
-var gitInfo    = require('git-repo-info');
+var gitVersion = require('git-repo-version');
 
 // --- Compile ES6 modules ---
 
@@ -55,7 +55,8 @@ generatedBowerConfig = replace(generatedBowerConfig, {
   pattern: {
     match: /VERSION_PLACEHOLDER/,
     replacement: function() {
-      return gitInfo().abbreviatedSha;
+      // remove leading `v` (since by default our tags use a `v` prefix)
+      return gitVersion().replace(/^v/, '');
     }
   }
 });

--- a/build-support/bower.json
+++ b/build-support/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-mocha",
-  "version": "0.4.1+pre.VERSION_PLACEHOLDER",
+  "version": "VERSION_PLACEHOLDER",
   "authors": [
     "Dan Gebhardt",
     "Robert Jackson"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-string-replace": "0.0.2",
-    "git-repo-info": "^1.0.2",
+    "git-repo-version": "^0.1.1",
     "testem": "0.6.38"
   }
 }


### PR DESCRIPTION
[git-repo-version](https://github.com/cibernox/git-repo-version)
automatically combines the `package.json` version with the current SHA,
unless the current SHA also has a tag associated with it.

This removes to need to hand edit the `build-support/bower.json` file
for every version bump.