### PR TITLE
Add chai and mocha ES6 shims.

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,0 +1,4 @@
+/* globals chai */
+
+export var expect = chai.expect;
+export var assert = chai.assert;

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,0 +1,11 @@
+/* globals mocha, describe, it */
+
+export {
+  mocha,
+  describe,
+  it,
+  before,
+  beforeEach,
+  after,
+  afterEach
+};

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -1,0 +1,8 @@
+import { describe, it } from 'mocha';
+
+describe('mocha-shim', function() {
+  it('should work', function() {
+    window.expect(describe).to.equal(window.describe);
+    window.expect(it).to.equal(window.it);
+  });
+});

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -1,8 +1,16 @@
 import { describe, it } from 'mocha';
+import { expect, assert } from 'chai';
 
 describe('mocha-shim', function() {
   it('should work', function() {
     window.expect(describe).to.equal(window.describe);
     window.expect(it).to.equal(window.it);
+  });
+});
+
+describe('chai-shim', function() {
+  it('should work', function() {
+    window.expect(expect).to.equal(window.chai.expect);
+    window.expect(assert).to.equal(window.chai.assert);
   });
 });


### PR DESCRIPTION
Allows the following:

```javascript
import { describe, it } from 'mocha';
import { expect } from 'chai';
```