### PR TITLE
Expose Chai helpers for custom assertions

### DIFF
--- a/lib/chai.js
+++ b/lib/chai.js
@@ -2,3 +2,6 @@
 
 export var expect = chai.expect;
 export var assert = chai.assert;
+
+export var use = chai.use;
+export var Assertion = chai.Assertion;


### PR DESCRIPTION
Chai exposes some [utilities for creating plugins](http://chaijs.com/guide/plugins/), e.g. for defining custom assertions. This change just propagates that exposure through the module shim.