### PR TITLE
Asynchronous module hooks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.4.1"
+    "ember-test-helpers": "ef4/ember-test-helpers#async-module-hooks"
   },
   "devDependencies": {
     "mocha": "~2.1.0",

--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -22,17 +22,19 @@ export function createModule(Constructor, name, description, callbacks, tests, m
 
   function moduleBody() {
     beforeEach(function() {
-      module.setup();
-      var context = getContext();
-      var keys = Ember.keys(context);
-      for (var i = 0; i < keys.length; i++) {
-        var key = keys[i];
-        this[key] = context[key];
-      }
+      var self = this;
+      return module.setup().then(function() {
+        var context = getContext();
+        var keys = Ember.keys(context);
+        for (var i = 0; i < keys.length; i++) {
+          var key = keys[i];
+          self[key] = context[key];
+        }
+      });
     });
 
     afterEach(function() {
-      module.teardown();
+      return module.teardown();
     });
 
     tests = tests || function() {};


### PR DESCRIPTION
This allows you to return a promise from your setup and teardown hooks to complete asynchronous actions before moving on-- which is consistent with mocha's normal convention.

It depends on https://github.com/switchfly/ember-test-helpers/pull/32