### PR TITLE
Update to use newer ember-mocha-adapter

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "mocha": "~2.1.0",
     "chai": "~1.10.0",
-    "ember-mocha-adapter": "~0.2.1",
+    "ember-mocha-adapter": "~0.3.1",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "jquery": "~2.1.1",

--- a/build-support/bower.json
+++ b/build-support/bower.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "mocha": "~2.1.0",
     "chai": "~1.10.0",
-    "ember-mocha-adapter": "~0.2.1"
+    "ember-mocha-adapter": "~0.3.1"
   },
   "devDependencies": { }
 }


### PR DESCRIPTION
I've been using this new version of ember-mocha-adapter successfully. It fixes some asynchronicity bugs.