### PR TITLE
Update ember-test-helpers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.5.0"
+    "ember-test-helpers": "^0.5.1"
   },
   "devDependencies": {
     "mocha": "~2.2.4",


### PR DESCRIPTION
This wil remove the deprecation warnings. Fixes https://github.com/switchfly/ember-mocha/issues/42