### PR TITLE
Update ember-test-helpers minimum version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.5.8"
+    "ember-test-helpers": "^0.5.9"
   },
   "devDependencies": {
     "mocha": "~2.2.4",


### PR DESCRIPTION
Allows mocking factories in integration tests.