### PR TITLE
Make `beforeEach` and `afterEach` use Ember.run

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,4 +1,71 @@
-/* globals mocha, describe, it, before, beforeEach, after, afterEach */
+/*global mocha, describe, it, before, after */
+
+
+/**
+ * Takes a function that defines a mocha hook, like `beforeEach` and
+ * runs its callback inside an `Ember.run`.
+ *
+ * In the canonical mocha style, beforeEach/afterEach blocks are for
+ * taking actions that have potentially asynchronous side effects like
+ * making network requests, and in the case of ember doing things like
+ * sending events, or visiting pages. In the context of an Ember
+ * application this more often than not means doing something inside
+ * of an `Ember.run`. The resulting wrapper has a reference to
+ * original hook function as the `withoutEmberRun`. E.g.
+ *
+ *   import { beforeEach } from 'mocha';
+ *
+ *   beforeEach(function {
+ *     // this is run inside `Ember.run`
+ *   })
+
+ *   beforeEach.withoutEmberRun(function({
+ *    // this is not inside `Ember.run`
+ *   }))
+ *
+ * You should almost never need to use the version without `Ember.run`
+ *
+ * Mocha supports two invocation styles for its hooks depending on the
+ * synchronization requirements of the setup code, and this wrapper
+ * supports both of them.
+ *
+ * As normal, if the setup code returns a promise, the testcase will
+ * wait until the promise is settled.
+
+ * @param {Function} original The native mocha hook to wrap
+ * @returns {Function} the wrapped hook
+ * @private
+ */
+function wrapMochaHookInEmberRun(original) {
+  function wrapper(fn) {
+    // the callback expects a `done` parameter
+    if (fn.length) {
+      return original(function(done) {
+        return Ember.run((function(_this) {
+          return function() {
+            return fn.call(_this, done);
+          };
+        })(this));
+      });
+    } else {
+      // no done parameter.
+      return original(function() {
+        return Ember.run((function(_this) {
+          return function() {
+            return fn.call(_this);
+          };
+        })(this));
+      });
+    }
+  }
+  wrapper.withoutEmberRun = original;
+  return wrapper;
+}
+
+
+
+var beforeEach = wrapMochaHookInEmberRun(window.beforeEach);
+var afterEach = wrapMochaHookInEmberRun(window.afterEach);
 
 export {
   mocha,

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -8,8 +8,8 @@ describe('mocha-shim', function() {
     window.chai.expect(it).to.equal(window.it);
     window.chai.expect(before).to.equal(window.before);
     window.chai.expect(after).to.equal(window.after);
-    window.chai.expect(beforeEach).to.equal(window.beforeEach);
-    window.chai.expect(afterEach).to.equal(window.afterEach);
+    window.chai.expect(beforeEach.withoutEmberRun).to.equal(window.beforeEach);
+    window.chai.expect(afterEach.withoutEmberRun).to.equal(window.afterEach);
   });
 });
 

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -2,6 +2,17 @@ import { mocha, describe, it, before, after, beforeEach, afterEach } from 'mocha
 import { expect, assert } from 'chai';
 
 describe('mocha-shim', function() {
+  beforeEach(function() {
+    this.beforeEachRunInEmberRunLoop = Ember.run.currentRunLoop;
+  });
+  afterEach(function() {
+    expect(Ember.run.currentRunLoop).to.be.ok;
+  });
+
+  it('runs the beforeEach hook inside the run loop', function() {
+    expect(this.beforeEachRunInEmberRunLoop).to.be.ok;
+  });
+
   it('should work', function() {
     window.chai.expect(mocha).to.equal(window.mocha);
     window.chai.expect(describe).to.equal(window.describe);


### PR DESCRIPTION
This wraps the versions of `beforeEach` and `afterEach` that ship with
mocha in versions that invoke their callbacks inside of the Ember run
loop.

In all of the Ember applications that we have ever used mocha to
test (which at this point is several over the past couple years), it has
always been the case that we ended up wrapping setup and teardown
blocks inside of an Ember.run, and so they all ended up having code that
wrapped the stock beforeEach/afterEach hooks in an ember run.

This reinforces the BDD style of having side effects inside your
setup/teardown blocks, and have your `it` blocks be read-only that query
and assert on current state.

In the context of an Ember.run, this means doing setup with side-effects
like dispatching events, propagating bindings, or performing route
transitions inside an ember run. That is all to say, that the default
should always be to use `Ember.run`. In the unlikely event that a setup
hook should be run outside of the run loop, a reference to the unwrapped
original mocha function is provided with the `withoutEmberRun`
property. E.g.

   beforEach.withoutEmberRun(function() {
     // no run loop.
   });

It should be noted that this intentionally wraps `beforeEach` and
`afterEach`, but leaves `before` and `after` alone since those blocks
are run before the application is actually instantiated and usually are
dedicated to suite-level concerns like stubbing global browser objects,
and other non Ember-y things.

It may be that those could be wrapped as well, but we don't really have
the experience to make a call either way.