### PR TITLE
Add shim for context

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,4 +1,4 @@
-/*global mocha, describe, it, before, after */
+/*global mocha, describe, context, it, before, after */
 
 
 /**
@@ -70,6 +70,7 @@ var afterEach = wrapMochaHookInEmberRun(window.afterEach);
 export {
   mocha,
   describe,
+  context,
   it,
   before,
   beforeEach,

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -1,4 +1,4 @@
-import { mocha, describe, it, before, after, beforeEach, afterEach } from 'mocha';
+import { mocha, describe, context, it, before, after, beforeEach, afterEach } from 'mocha';
 import { expect, assert } from 'chai';
 
 describe('mocha-shim', function() {
@@ -16,6 +16,7 @@ describe('mocha-shim', function() {
   it('should work', function() {
     window.chai.expect(mocha).to.equal(window.mocha);
     window.chai.expect(describe).to.equal(window.describe);
+    window.chai.expect(context).to.equal(window.context);
     window.chai.expect(it).to.equal(window.it);
     window.chai.expect(before).to.equal(window.before);
     window.chai.expect(after).to.equal(window.after);


### PR DESCRIPTION
Mocha's [BDD interface](https://mochajs.org/#bdd) includes `context()`, an alias for `describe()` (they are `===`). This functionality is already provided by `ember-mocha`. However, this will fail JSHint if used as a global function, and yet cannot be imported as there is no shim for it.

This PR adds a shim for `context`.