### PR TITLE
Preserve suite context in outer test function

### DIFF
--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -38,7 +38,7 @@ export function createModule(Constructor, name, description, callbacks, tests, m
     });
 
     tests = tests || function() {};
-    tests();
+    tests.call(this);
   }
   if (method) {
     describe[method](module.name, moduleBody);

--- a/tests/mocha-module-test.js
+++ b/tests/mocha-module-test.js
@@ -1,10 +1,11 @@
 import { createModule } from 'ember-mocha/mocha-module';
 import { TestModule } from 'ember-test-helpers';
-import { describe, it, before, after, beforeEach, afterEach } from 'mocha';
+import { describe, it, before, after, beforeEach, afterEach, mocha } from 'mocha';
 import { expect } from 'chai';
 
 describe('MochaModule', function() {
   createModule(TestModule, 'component:x-foo', 'context', function() {
+    var testFunctionContext = this;
     var thisInBefore, thisInBeforeEach;
 
     before(function() {
@@ -17,6 +18,9 @@ describe('MochaModule', function() {
       expect(this).to.be.defined;
       expect(this).to.equal(thisInBefore);
       expect(this).to.equal(thisInBeforeEach);
+    });
+    it("preserves mocha suite context in outer test function", function() {
+      expect(testFunctionContext).to.be.an.instanceof(mocha.suite.constructor);
     });
     afterEach(function() {
       expect(this).to.equal(thisInBeforeEach);


### PR DESCRIPTION
Mimics the behavior of mocha's `describe` so that one can for instance set the suite timeout:

```javascript
describeModel('my-model', 'My model', {}, function() {
  this.timeout(5000);
});
```