### PR TITLE
Unlocked Mocha dependency, fixes #68

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "ember-test-helpers": "^0.5.17"
   },
   "devDependencies": {
-    "mocha": "~2.2.4",
+    "mocha": "2.x",
     "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1",
     "loader": "stefanpenner/loader.js#1.0.1",


### PR DESCRIPTION
Mocha is now locked at `2.x` which is equivalent to `>= 2.0.0, < 3.0.0`.