### PR TITLE
Update dependencies as far as possible, make tests green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-node_modules
-bower_components
-tmp
-dist
-build
+/.node-version
+/bower_components
+/build
+/dist
+/node_modules
+/npm-debug.log
+/tmp

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -15,16 +15,18 @@ var loader = new Funnel('bower_components', {
 });
 
 // TODO - this manual dependency management has got to go!
-var klassy = new Funnel('bower_components', {
+var klassy = new Funnel('node_modules', {
   srcDir: '/klassy/lib',
   files: ['klassy.js'],
   destDir: '/'
 });
+
 var emberTestHelpers = new Funnel('bower_components', {
   srcDir: '/ember-test-helpers/lib',
   include: [/.js$/],
   destDir: '/'
 });
+
 var deps = mergeTrees([klassy, emberTestHelpers]);
 
 var lib = new Funnel('lib', {
@@ -40,6 +42,7 @@ var tests = new Funnel('tests', {
 });
 
 var main = mergeTrees([deps, lib]);
+
 main = concat(new compileES6(main), {
   inputFiles: ['**/*.js'],
   outputFile: '/ember-mocha.amd.js'
@@ -50,6 +53,7 @@ var generatedBowerConfig = new Funnel('build-support', {
   destDir: '/',
   files: ['bower.json']
 });
+
 generatedBowerConfig = replace(generatedBowerConfig, {
   files: ['bower.json'],
   pattern: {
@@ -120,7 +124,8 @@ var adapter = new Funnel('bower_components', {
 var testSupport = concat('bower_components', {
   inputFiles: [
     'ember-cli-shims/app-shims.js',
-    '../tests/test-support/test-loader.js'],
+    '../tests/test-support/test-loader.js'
+  ],
   outputFile: '/assets/test-support.js'
 });
 

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -9,12 +9,13 @@ var gitVersion = require('git-repo-version');
 // --- Compile ES6 modules ---
 
 var loader = new Funnel('bower_components', {
-  srcDir: 'loader',
+  srcDir: 'loader.js',
   files: ['loader.js'],
   destDir: '/assets/'
 });
 
 // TODO - this manual dependency management has got to go!
+
 var klassy = new Funnel('node_modules', {
   srcDir: '/klassy/lib',
   files: ['klassy.js'],

--- a/bower.json
+++ b/bower.json
@@ -9,20 +9,20 @@
   "license": "Apache Version 2.0",
   "ignore": [
     "**/.*",
-    "node_modules",
     "bower_components",
+    "node_modules",
     "tests"
   ],
   "dependencies": {
     "ember": "^1.10.0",
-    "ember-test-helpers": "^0.5.17"
+    "ember-test-helpers": "0.5.16"
   },
   "devDependencies": {
     "mocha": "~2.3.4",
     "chai": "~3.4.2",
     "ember-mocha-adapter": "~0.3.1",
-    "loader": "stefanpenner/loader.js#1.0.1",
-    "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
+    "loader.js": "~3.5.0",
+    "ember-cli-shims": "~0.1.0",
     "pretender": "^0.6.0",
     "jquery": "~2.1.4",
     "ember-data": "~1.0.0-beta.10"

--- a/bower.json
+++ b/bower.json
@@ -18,16 +18,17 @@
     "ember-test-helpers": "^0.5.17"
   },
   "devDependencies": {
-    "mocha": "~2.2.4",
-    "chai": "~2.3.0",
+    "mocha": "~2.3.4",
+    "chai": "~3.4.2",
     "ember-mocha-adapter": "~0.3.1",
     "loader": "stefanpenner/loader.js#1.0.1",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
     "pretender": "^0.6.0",
-    "jquery": "~2.1.1",
+    "jquery": "~2.1.4",
     "ember-data": "~1.0.0-beta.10"
   },
   "resolutions": {
+    "ember": "^1.10.0",
     "ember-data": "canary"
   }
 }

--- a/build-support/bower.json
+++ b/build-support/bower.json
@@ -8,8 +8,8 @@
   "license": "Apache Version 2.0",
   "ignore": [ ],
   "dependencies": {
-    "mocha": "~2.2.4",
-    "chai": "~2.3.0",
+    "mocha": "~2.3.4",
+    "chai": "~3.4.2",
     "ember-mocha-adapter": "~0.3.1"
   },
   "devDependencies": { }

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,8 +1,8 @@
-/* globals chai */
+/*globals chai */
 
 export var expect = chai.expect;
 export var assert = chai.assert;
 
-export var config = chai.config;
-export var use = chai.use;
+export var config    = chai.config;
+export var use       = chai.use;
 export var Assertion = chai.Assertion;

--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -49,12 +49,12 @@ export function createModule(Constructor, name, description, callbacks, tests, m
 
 export function createOnly(Constructor) {
   return function(name, description, callbacks, tests) {
-    createModule(Constructor, name, description, callbacks, tests, "only");
+    createModule(Constructor, name, description, callbacks, tests, 'only');
   };
 }
 
 export function createSkip(Constructor) {
   return function(name, description, callbacks, tests) {
-    createModule(Constructor, name, description, callbacks, tests, "skip");
+    createModule(Constructor, name, description, callbacks, tests, 'skip');
   };
 }

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -1,6 +1,5 @@
 /*global mocha, describe, context, it, before, after */
 
-
 /**
  * Takes a function that defines a mocha hook, like `beforeEach` and
  * runs its callback inside an `Ember.run`.
@@ -62,10 +61,8 @@ function wrapMochaHookInEmberRun(original) {
   return wrapper;
 }
 
-
-
 var beforeEach = wrapMochaHookInEmberRun(window.beforeEach);
-var afterEach = wrapMochaHookInEmberRun(window.afterEach);
+var afterEach  = wrapMochaHookInEmberRun(window.afterEach);
 
 export {
   mocha,

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "broccoli-merge-trees": "^0.1.4",
     "broccoli-sourcemap-concat": "^0.4.3",
     "broccoli-string-replace": "0.0.2",
-    "ember-cli": "^0.1.12",
+    "ember-cli": "^0.1.15",
     "ember-cli-release": "^0.2.7",
     "exists-sync": "0.0.3",
-    "git-repo-version": "^0.1.1"
+    "git-repo-version": "^0.1.1",
+    "klassy": "^0.1.3"
   }
 }

--- a/tests/describe-component-test.js
+++ b/tests/describe-component-test.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 var PrettyColor = Ember.Component.extend({
   classNames: ['pretty-color'],
   attributeBindings: ['style'],
-  style: function(){
+  style: function() {
     return 'color: ' + this.get('name') + ';';
   }.property('name')
 });
@@ -24,19 +24,18 @@ function setupRegistry() {
 ///////////////////////////////////////////////////////////////////////////////
 
 describe('describeComponent', function() {
-
   describeComponent('x-foo', {
-
     beforeSetup: function() {
       setupRegistry();
     }
-
   }, function() {
-
     it('renders', function() {
       var component = this.subject();
+
       expect(component._state).to.equal('preRender');
+
       this.render();
+
       expect(component._state).to.equal('inDOM');
     });
 
@@ -49,7 +48,7 @@ describe('describeComponent', function() {
 
     it('yields', function() {
       var component = this.subject({
-        layout: Ember.Handlebars.compile("yield me")
+        layout: Ember.Handlebars.compile('yield me')
       });
       expect(component._state).to.equal('preRender');
       this.render();
@@ -73,23 +72,19 @@ describe('describeComponent', function() {
     });
   });
 
-
   ///////////////////////////////////////////////////////////////////////////////
 
   describeComponent('pretty-color', {
-
     beforeSetup: function() {
       setupRegistry();
     }
-
   }, function() {
-
-    it("has the correct className", function() {
-      // first call to this.$() renders the component.
+    it('has the correct className', function() {
+      // First call to `this.$()` renders the component.
       expect(this.$().is('.pretty-color')).to.be.true;
     });
 
-    it("uses the correct custom template", function() {
+    it('uses the correct custom template', function() {
       var component = this.subject();
 
       expect($.trim(this.$().text())).to.equal('Pretty Color:');
@@ -101,7 +96,7 @@ describe('describeComponent', function() {
       expect($.trim(this.$().text())).to.equal('Pretty Color: green');
     });
 
-    it("$", function() {
+    it('$', function() {
       var component = this.subject({name: 'green'});
       expect($.trim(this.$('.color-name').text())).to.equal('green');
       expect($.trim(this.$().text())).to.equal('Pretty Color: green');
@@ -109,21 +104,23 @@ describe('describeComponent', function() {
   });
 
   describeComponent.skip('skipped component', function() {
-    it("is skipped", function() {});
+    it('is skipped', function() {});
   });
+
   var grep = grepFor(function() {
     describeComponent.only('only component', function() {
-      it("is the only spec");
+      it('is the only spec');
     });
   });
 
-  describe("skipping and grepping", function() {
-    it("skips the skipped context", function() {
+  describe('skipping and grepping', function() {
+    it('skips the skipped context', function() {
       var skipped = window.mocha.suite.suites.find(function(suite) {
-        return suite.title === "skipped component" && suite.pending;
+        return suite.title === 'skipped component' && suite.pending;
       });
     });
-    it("greps for describeComponent.only", function() {
+
+    it('greps for describeComponent.only', function() {
       expect('describeComponent component:only component').to.match(grep);
     });
   });

--- a/tests/describe-model-test.js
+++ b/tests/describe-model-test.js
@@ -27,9 +27,7 @@ function setupRegistry() {
 ///////////////////////////////////////////////////////////////////////////////
 
 describe('describeModel', function() {
-
   describeModel('whazzit', 'model:whazzit without adapter', {
-
     beforeSetup: function() {
       setupRegistry();
     },
@@ -37,9 +35,7 @@ describe('describeModel', function() {
     setup: function() {
       Whazzit.FIXTURES = [];
     }
-
   }, function() {
-
     it('store exists', function() {
       var store = this.store();
       expect(store).to.be.an.instanceof(DS.Store);
@@ -65,7 +61,6 @@ describe('describeModel', function() {
   ///////////////////////////////////////////////////////////////////////////////
 
   describeModel('whazzit', 'model:whazzit with custom adapter', {
-
     needs: ['adapter:whazzit'],
 
     beforeSetup: function() {
@@ -83,9 +78,7 @@ describe('describeModel', function() {
       }
       whazzitAdapterFindAllCalled = false;
     }
-
   }, function() {
-
     it('uses the WhazzitAdapter', function() {
       var model = this.subject(),
           store = this.store();
@@ -108,13 +101,11 @@ describe('describeModel', function() {
         });
       });
     });
-
   });
 
   ///////////////////////////////////////////////////////////////////////////////
 
   describeModel('whazzit', 'model:whazzit with application adapter', {
-
     needs: ['adapter:application'],
 
     beforeSetup: function() {
@@ -124,9 +115,7 @@ describe('describeModel', function() {
     setup: function() {
       Whazzit.FIXTURES = [];
     }
-
   }, function() {
-
     it('uses the ApplicationAdapter', function() {
       var model = this.subject(),
           store = this.store();
@@ -134,27 +123,26 @@ describe('describeModel', function() {
       expect(store.adapterFor(model.constructor)).to.be.an.instanceof(ApplicationAdapter);
       expect(store.adapterFor(model.constructor)).to.not.be.an.instanceof(WhazzitAdapter);
     });
-
   });
 
-
-  describeModel.skip("skipped model", function() {
-    it("is skipped", function() {});
+  describeModel.skip('skipped model', function() {
+    it('is skipped', function() {});
   });
 
   var grep = grepFor(function() {
-    describeModel.only("whazzit", "only model", function() {
-      it("is the only model", function() {});
+    describeModel.only('whazzit', 'only model', function() {
+      it('is the only model', function() {});
     });
   });
 
-  describe("skipping and grepping", function() {
-    it("skips the skipped context", function() {
+  describe('skipping and grepping', function() {
+    it('skips the skipped context', function() {
       var skipped = window.mocha.suite.suites.find(function(suite) {
-        return suite.title === "skipped model" && suite.pending;
+        return suite.title === 'skipped model' && suite.pending;
       });
     });
-    it("greps for describeModel.only", function() {
+
+    it('greps for describeModel.only', function() {
       expect('describeModel only model').to.match(grep);
     });
   });

--- a/tests/describe-module-test.js
+++ b/tests/describe-module-test.js
@@ -12,13 +12,11 @@ function setupRegistry() {
 
 var callbackOrder, setupContext, teardownContext, beforeSetupContext, afterTeardownContext;
 
-describe("describeModule", function() {
-
+describe('describeModule', function() {
   describeModule('component:x-foo', 'TestModule callbacks', {
     beforeSetup: function() {
       beforeSetupContext = this;
       callbackOrder = [ 'beforeSetup' ];
-
       setupRegistry();
     },
 
@@ -45,30 +43,30 @@ describe("describeModule", function() {
       expect(afterTeardownContext).to.equal(beforeSetupContext);
       expect(afterTeardownContext).to.not.equal(teardownContext);
     }
-
   }, function() {
-    it("should call setup callbacks in the correct order", function() {
+    it('should call setup callbacks in the correct order', function() {
       expect(callbackOrder).to.deep.equal([ 'beforeSetup', 'setup' ]);
     });
   });
 
-  describeModule.skip("skipped module", function() {
-    it("is skipped", function() {});
+  describeModule.skip('skipped module', function() {
+    it('is skipped', function() {});
   });
 
   var grep = grepFor(function() {
-    describeModule.only("component:x-foo", "only module", function() {
-      it("is the only module", function() {});
+    describeModule.only('component:x-foo', 'only module', function() {
+      it('is the only module', function() {});
     });
   });
 
-  describe("skipping and grepping", function() {
-    it("skips the skipped context", function() {
+  describe('skipping and grepping', function() {
+    it('skips the skipped context', function() {
       var skipped = window.mocha.suite.suites.find(function(suite) {
-        return suite.title === "skipped module" && suite.pending;
+        return suite.title === 'skipped module' && suite.pending;
       });
     });
-    it("greps for describeModule.only", function() {
+
+    it('greps for describeModule.only', function() {
       expect('describeModule only module').to.match(grep);
     });
   });

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,24 +1,28 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Ember-Mocha Tests</title>
-  <link rel="stylesheet" href="/assets/mocha.css">
-</head>
-<body>
-  <div id="mocha"></div>
-  <div id="mocha-fixture"></div>
-  <script src="/assets/vendor.js"></script>
-  <script src="/assets/mocha.js"></script>
-  <script src="/assets/chai.js"></script>
-  <script src="/assets/adapter.js"></script>
-  <script src="/assets/loader.js"></script>
-  <script src="/assets/ember-mocha-tests.amd.js"></script>
-  <script src="/assets/test-support.js"></script>
-  <script>
-    $(document).ready(function(){
-      mocha.run();
-    });
-  </script>
-</body>
+  <head>
+    <meta charset="utf-8">
+
+    <title>Ember-Mocha Tests</title>
+
+    <link rel="stylesheet" href="/assets/mocha.css">
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="mocha-fixture"></div>
+
+    <script src="/assets/vendor.js"></script>
+    <script src="/assets/mocha.js"></script>
+    <script src="/assets/chai.js"></script>
+    <script src="/assets/adapter.js"></script>
+    <script src="/assets/loader.js"></script>
+    <script src="/assets/ember-mocha-tests.amd.js"></script>
+    <script src="/assets/test-support.js"></script>
+    <script>
+      $(document).ready(function() {
+        mocha.run();
+      });
+    </script>
+  </body>
 </html>

--- a/tests/it-test.js
+++ b/tests/it-test.js
@@ -52,7 +52,6 @@ describe('it', function() {
     expect(pendingSpec).to.be.ok;
   });
 
-
   it('correctly sets mocha grep options for runing a single test case with.only', function() {
     expect(mochaGrep).to.match(/it runs this test/);
   });
@@ -80,5 +79,4 @@ describe('it', function() {
   };
 
   var wrapper = it('testing test report string representation', callback);
-
 });

--- a/tests/mocha-module-test.js
+++ b/tests/mocha-module-test.js
@@ -10,17 +10,21 @@ describe('MochaModule', function() {
     before(function() {
       thisInBefore = this;
     });
+
     beforeEach(function() {
       thisInBeforeEach = this;
     });
-    it("is preserved inside all assertions and hooks", function() {
+
+    it('is preserved inside all assertions and hooks', function() {
       expect(this).to.be.defined;
       expect(this).to.equal(thisInBefore);
       expect(this).to.equal(thisInBeforeEach);
     });
+
     afterEach(function() {
       expect(this).to.equal(thisInBeforeEach);
     });
+
     after(function() {
       expect(this).to.equal(thisInBefore);
       expect(this).to.equal(thisInBeforeEach);

--- a/tests/shims-test.js
+++ b/tests/shims-test.js
@@ -5,6 +5,7 @@ describe('mocha-shim', function() {
   beforeEach(function() {
     this.beforeEachRunInEmberRunLoop = Ember.run.currentRunLoop;
   });
+
   afterEach(function() {
     expect(Ember.run.currentRunLoop).to.be.ok;
   });

--- a/tests/test-support/test-loader.js
+++ b/tests/test-support/test-loader.js
@@ -1,4 +1,4 @@
-/* globals requirejs, require */
+/*globals requirejs, require */
 
 var TestLoader = function() {
 };
@@ -23,5 +23,4 @@ TestLoader.load = function() {
   new TestLoader().loadModules();
 };
 
-//export default TestLoader;
 TestLoader.load();


### PR DESCRIPTION
Hey there,

this commit updates the dependencies as far as possible (`ember-test-helpers` > 0.5.16 breaks `describe-component-test.js`), all tests should be pass, fixes #68 and minor formatting changes.

PS: I you like the changes, i can squash them before.

Thanks for ember-mocha and happy new year!