### PR TITLE
Adjust "mocha" dependency to allow 2.3, 2.4, ... releases

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "ember": "^1.10.0"
   },
   "devDependencies": {
-    "mocha": "~2.2.4",
+    "mocha": "^2.2.4",
     "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1",
     "loader": "stefanpenner/loader.js#1.0.1",


### PR DESCRIPTION
This PR continues where #68 left off. It allows Ember projects to use more recent versions of mocha without manually having to resolve any bower version conflicts.