### PR TITLE
Share Mocha's test context.

### DIFF
--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -21,16 +21,10 @@ export function createModule(Constructor, name, description, callbacks, tests, m
 
   function moduleBody() {
     beforeEach(function() {
-      var self = this;
-      return module.setup().then(function() {
-        var context = getContext();
-        var keys = Object.keys(context);
-        for (var i = 0; i < keys.length; i++) {
-          var key = keys[i];
-          self[key] = context[key];
-        }
-      });
-    });
+      module.setContext(this);
+
+      return module.setup();
+    },
 
     afterEach(function() {
       return module.teardown();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "resolve": "^1.1.7"
   },
   "dependencies": {
-    "ember-test-helpers": "^0.5.22"
+    "ember-test-helpers": "^0.5.32"
   }
 }


### PR DESCRIPTION
This ensures that the contexts in various `mocha` hooks are the same as the hooks used in unit/integration tests.