### PR TITLE
Share Mocha's test context.

### DIFF
--- a/lib/ember-mocha/mocha-module.js
+++ b/lib/ember-mocha/mocha-module.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { beforeEach, afterEach, describe } from 'mocha';
-import { getContext } from 'ember-test-helpers';
 
 export function createModule(Constructor, name, description, callbacks, tests, method) {
   Ember.deprecate(
@@ -29,12 +28,9 @@ export function createModule(Constructor, name, description, callbacks, tests, m
 
   function moduleBody() {
     beforeEach(function() {
-      return module.setup().then(() => {
-        var context = getContext();
-        Object.keys(context).forEach(key => {
-          this[key] = context[key];
-        });
-      });
+      module.setContext(this);
+
+      return module.setup();
     });
 
     afterEach(function() {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "resolve": "^1.1.7"
   },
   "dependencies": {
-    "ember-test-helpers": "^0.5.22"
+    "ember-test-helpers": "^0.5.33"
   }
 }


### PR DESCRIPTION
This ensures that the contexts in various `mocha` hooks are the same as
the hooks used in unit/integration tests.

[Rebase of #87]